### PR TITLE
return false on exception

### DIFF
--- a/prod/scanner.py
+++ b/prod/scanner.py
@@ -36,13 +36,16 @@ def setup():
 def send_scans(scans):
     global SCRIPT_ID, HMAC_KEY
     url = "https://script.google.com/macros/s/" + SCRIPT_ID + "/exec"
-    scan_string = json.dumps(scans)
-    key = base64.b64decode(HMAC_KEY.encode("ascii"))
-    signature = hmac.digest(key, scan_string, "sha384")
-    sigenc = base64.b64encode(signature).decode("ascii")
-    
-    r = requests.post(url, params={"signature":sigenc}, data=scan_string, headers={"Content-Type":"application/json"})
-    if r.status_code != 200 or r.text != "success":
+    try:
+        scan_string = json.dumps(scans)
+        key = base64.b64decode(HMAC_KEY.encode("ascii"))
+        signature = hmac.digest(key, scan_string, "sha384")
+        sigenc = base64.b64encode(signature).decode("ascii")
+
+        r = requests.post(url, params={"signature":sigenc}, data=scan_string, headers={"Content-Type":"application/json"})
+        if r.status_code != 200 or r.text != "success":
+            return False
+    except:
         return False
     
     return True

--- a/prod/scanner.py
+++ b/prod/scanner.py
@@ -78,8 +78,8 @@ def handle_scans(scan_queue):
             c.executemany("INSERT INTO scans VALUES (?,?,?)", [(s["card_number"], s["timestamp"], s["scan_id"]) for s in scans])
         else:
             # if scans are send successfully fetch all scans from the local database and send them as well
+            scans = []
             for row in c.execute("SELECT card_number, time_stamp, scan_id FROM scans"):
-                scans = []
                 scans.append({
                     "scan_id":row[2],
                     "timestamp":row[1],

--- a/prod/scanner.py
+++ b/prod/scanner.py
@@ -39,7 +39,7 @@ def send_scans(scans):
     try:
         scan_string = json.dumps(scans)
         key = base64.b64decode(HMAC_KEY.encode("ascii"))
-        signature = hmac.digest(key, scan_string, "sha384")
+        signature = hmac.digest(key, scan_string.encode("ascii"), "sha384")
         sigenc = base64.b64encode(signature).decode("ascii")
 
         r = requests.post(url, params={"signature":sigenc}, data=scan_string, headers={"Content-Type":"application/json"})


### PR DESCRIPTION
Currently in a network down condition `send_scans` will throw an error and prevent further processing of scans. This will prevent scans from being cached to the database and will result in scans being lost if there is no internet connection. This change catches any errors during the process of sending the HTTP request and returns `False` when one is caught to allow further processing to continue (storing scans in local db).